### PR TITLE
Split and alphabetised list

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ These are resources that will help you contribute to projects (and can be contri
 
 ## Inactive projects
 
-List of projects which no longer accept contributions but are still interesting.
+These are projects which no longer accept contributions but are still interesting.
 
 - [Code And Talk](https://github.com/szabgab/codeandtalk.com): Collecting data about tech conferences in JSON files. The README has links to the file describing how to add [Events](https://github.com/szabgab/codeandtalk.com/blob/main/docs/EVENTS.md) to the "database".
 - [Liar Game](https://github.com/fibanneacci/liar): A web-based multiplayer game. Contribute to the list of categories / words!
 
 ## Contributing to this list
 
-If you'd like to add an item, please provide a brief description what non-programmers can do and how can they contribute to that project. Include a link directly to the page that explains how and what to contribute..
+If you'd like to add an item, please submit a pull request with a brief description what non-programmers can do and how can they contribute to that project. Include a link directly to the page that explains how and what to contribute.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -14,43 +14,43 @@ These are projects and lists of projects you can contribue to.
 
 - [List of all the awesome lists](https://github.com/szabgab/awesome-lists) - A collection of URLs. Excellent way to send your first pull-request.
 - [List of Open Source projects](https://github.com/OSDC-Code-Maven/open-source-by-organizations/) by corporations, Higher Education Institutions, and governments
-- [Kantoniko](https://github.com/kantoniko/): The corner of Ladino on the Internet. You can contribute voice recordings, words and sentences in Ladino, and translations.
-- [Cloud Native Glossary](https://github.com/cncf/glossary/blob/main/CONTRIBUTING.md): [CNCF Glossary](https://glossary.cncf.io) explains cloud-native concepts and the terminologies involved in that ecosystem in simple language and does not require any prior technical background to grasp them. Individuals can start contributing to it by localizing/translating or modifying current terms or proposing new terms.
-- [Common Voice](https://commonvoice.mozilla.org/en): Mozilla's initiative to help teach machines to understand speech. Everybody can [contribute voice recordings](https://commonvoice.mozilla.org/en/speak), [validate recordings](https://commonvoice.mozilla.org/en/listen), (only English so far) and [contribute sentences](https://commonvoice.mozilla.org/en/write) (all languages).
-- [Godot Engine](https://godotengine.org/): 2D and 3D cross-platform game engine. Help with [translating the engine and documentation](https://godotengine.org/article/godots-documentation-now-open-translation) or in [lots of other ways](https://contributing.godotengine.org/en/latest/organization/how_to_contribute.html).
 - [AI Language Partner](https://github.com/duct-tape2/ai-language-partner/blob/main/docs/community/CONTRIBUTOR_LANDING.md): Local-first Japanese speaking practice app for Korean learners. Non-programmers can improve Korean/Japanese docs, review beginner dialogue naturalness, and add learner notes through [first-timers-only issues](https://github.com/duct-tape2/ai-language-partner/labels/first-timers-only).
-- [LanguageTool](https://github.com/languagetool-org/languagetool): [LanguageTool](https://community.languagetool.org/) is an Open Source proofreading tool.
-- [swag-for-dev](https://github.com/swapagarwal/swag-for-dev): 😎👕🧦 A list of swag opportunities for developers.
-- [Oppia](https://github.com/oppia/oppia/wiki/Teaching-with-Oppia): [Oppia](https://www.oppia.org) is an online learning tool that enables anyone to easily create and share interactive activities.
 - [Awesome Animal Care](https://github.com/omkar-foss/awesome-animal-care): List of curated, practical information resources to care for dogs, cats, fishes, horses, parrots and others.
 - [Awesome App Ideas](https://github.com/tastejs/awesome-app-ideas): A list of app ideas. You can add your own app ideas. Non-Programmers can create app ideas for programmers looking through the list to solve.
 - [Awesome Fantasy](https://github.com/RichardLitt/awesome-fantasy): A list of fantasy books and TV-series that anyone can contribute to.
-- [DevJoke](https://github.com/shrutikapoor08/devjoke): #DevJoke. Submit a PR if you know a good dev joke.
-- [LaTeX Gboard Dictionary](https://github.com/DenverCoder1/LaTeX-Gboard-Dictionary/issues/5): ⌨ Add shortcuts to a Gboard dictionary to allow Unicode to be typed with simple shortcuts on Android ⚡.
-- [Open Source Practice and Resources](https://github.com/Ashish-khanagwal/Open-source-practice-and-resources): Make your first pull request with beginner friendly project, just add relevant resources which you find beneficial and adding values to your learning journey💪.
-- [Open Drinks](https://github.com/alfg/opendrinks): Submit drink recipes.
-- [The Sourdough Framework](https://github.com/hendricius/the-sourdough-framework): An opportunity to share your bread / sourdough recipes!
-- [Data Science Notes](https://github.com/wyattowalsh/data-science-notes): Share notes across topics in data science such as mathematics, visualization, and modeling!
 - [CheatSheets](https://github.com/Jahenr/CheatSheets): Cheat sheet documentation project that allows contributors to add and reference most common commands for systems we know and love in a single place.
+- [Cloud Native Glossary](https://github.com/cncf/glossary/blob/main/CONTRIBUTING.md): [CNCF Glossary](https://glossary.cncf.io) explains cloud-native concepts and the terminologies involved in that ecosystem in simple language and does not require any prior technical background to grasp them. Individuals can start contributing to it by localizing/translating or modifying current terms or proposing new terms.
+- [Common Voice](https://commonvoice.mozilla.org/en): Mozilla's initiative to help teach machines to understand speech. Everybody can [contribute voice recordings](https://commonvoice.mozilla.org/en/speak), [validate recordings](https://commonvoice.mozilla.org/en/listen), (only English so far) and [contribute sentences](https://commonvoice.mozilla.org/en/write) (all languages).
+- [Data Science Notes](https://github.com/wyattowalsh/data-science-notes): Share notes across topics in data science such as mathematics, visualization, and modeling!
+- [DevJoke](https://github.com/shrutikapoor08/devjoke): #DevJoke. Submit a PR if you know a good dev joke.
+- [Godot Engine](https://godotengine.org/): 2D and 3D cross-platform game engine. Help with [translating the engine and documentation](https://godotengine.org/article/godots-documentation-now-open-translation) or in [lots of other ways](https://contributing.godotengine.org/en/latest/organization/how_to_contribute.html).
+- [Kantoniko](https://github.com/kantoniko/): The corner of Ladino on the Internet. You can contribute voice recordings, words and sentences in Ladino, and translations.
+- [LanguageTool](https://github.com/languagetool-org/languagetool): [LanguageTool](https://community.languagetool.org/) is an Open Source proofreading tool.
+- [LaTeX Gboard Dictionary](https://github.com/DenverCoder1/LaTeX-Gboard-Dictionary/issues/5): ⌨ Add shortcuts to a Gboard dictionary to allow Unicode to be typed with simple shortcuts on Android ⚡.
+- [Open Drinks](https://github.com/alfg/opendrinks): Submit drink recipes.
+- [Open Source Practice and Resources](https://github.com/Ashish-khanagwal/Open-source-practice-and-resources): Make your first pull request with beginner friendly project, just add relevant resources which you find beneficial and adding values to your learning journey💪.
+- [Oppia](https://github.com/oppia/oppia/wiki/Teaching-with-Oppia): [Oppia](https://www.oppia.org) is an online learning tool that enables anyone to easily create and share interactive activities.
 - [Owncast](https://github.com/owncast/owncast): A self-hosted livestreaming video and chat server that allows you to build experiences similar, but not limited to, big tech owned services. A great project for those interested in design, media, documentation, tutorials or community engagement.
 - [PetMe](https://github.com/akshitagupta15june/PetMe): A platform for finding homes for animals in need, always open to contributions.
+- [The Sourdough Framework](https://github.com/hendricius/the-sourdough-framework): An opportunity to share your bread / sourdough recipes!
+- [swag-for-dev](https://github.com/swapagarwal/swag-for-dev): 😎👕🧦 A list of swag opportunities for developers.
 - [The Turing Way](https://github.com/alan-turing-institute/the-turing-way): A series of open source guides about data science and AI. Contributors can add to new and ongoing chapters, work on translation efforts, contribute to infrastructure maintenance work within the project, and more.
 
 ## The resources
 
 These are resources that will help you contribute to projects (and can be contributed to themselves!)
 
+- [A-to-Z-Resources-for-Students](https://github.com/dipakkr/A-to-Z-Resources-for-Students): This is a dynamic list for everything you need to know for coders and non-coders. Make yourself comfortable updating the list and using any of the resources listed.
 - [awesome-eli5](https://github.com/swapagarwal/awesome-eli5): 👶 Tech explained like you're five!
 - [awesome-inspiration](https://github.com/swapagarwal/awesome-inspiration): 🔥 A curated list of content worth sharing to help you get inspired! ⚡️.
-- [A-to-Z-Resources-for-Students](https://github.com/dipakkr/A-to-Z-Resources-for-Students): This is a dynamic list for everything you need to know for coders and non-coders. Make yourself comfortable updating the list and using any of the resources listed.
-- [Hello World](https://guides.github.com/activities/hello-world/): A short tutorial on how to start contributing with GitHub.
+- [Basic Github commands](https://github.com/LiviaGitHub/basic-github-commands): This repository serves as a comprehensive guide to the fundamental commands of Git. Whether you are a beginner or looking to refresh your knowledge, this repository provides clear explanations and practical examples of essential Git commands. Contributors can enhance this project by adding new chapters or expanding ongoing ones, working on translation efforts to make the content accessible to a broader audience, providing feedback and suggestions for better documentation.
+- [DX Knowledge Base](https://github.com/DXHeroes/knowledge-base-content): Open source Knowledge Base filled with articles about Developer Experience and related topics like software creation process and team management.
 - [First Contributions](https://github.com/firstcontributions/first-contributions): Quick guide on forks, pull requests and contributions.
 - [Flexbox Froggy](https://github.com/thomaspark/flexboxfroggy): Learn CSS Flexbox while playing!
-- [Learn Git branching](https://pcottle.github.io/learnGitBranching): Play the game and learn Git branching.
-- [DX Knowledge Base](https://github.com/DXHeroes/knowledge-base-content): Open source Knowledge Base filled with articles about Developer Experience and related topics like software creation process and team management.
 - [GitHub for Non-Programmers](https://github.com/tvanantwerp/github-for-non-programmers): Guide on using GitHub for workflows other than programming.
+- [Hello World](https://guides.github.com/activities/hello-world/): A short tutorial on how to start contributing with GitHub.
+- [Learn Git branching](https://pcottle.github.io/learnGitBranching): Play the game and learn Git branching.
 - [Useful repositories](https://github.com/Aatmaj-Zephyr/A-collection-of-useful-repositories): A collection of useful repositories which provide learning resources for developers.
-- [Basic Github commands](https://github.com/LiviaGitHub/basic-github-commands): This repository serves as a comprehensive guide to the fundamental commands of Git. Whether you are a beginner or looking to refresh your knowledge, this repository provides clear explanations and practical examples of essential Git commands. Contributors can enhance this project by adding new chapters or expanding ongoing ones, working on translation efforts to make the content accessible to a broader audience, providing feedback and suggestions for better documentation.
 
 ## Inactive projects
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Awesome for non-programmers
 
-Here comes a list of Open Source projects where you can contribute without any programming knowledge. Ways you can contribute include:
+Here comes a list of Open Source projects where you can contribute without any programming knowledge, as well as resources to help you. Ways you can contribute include:
 
 - Collecting data
 - Translating text
@@ -9,6 +9,8 @@ Here comes a list of Open Source projects where you can contribute without any p
 Inspired by [Awesome First Pull Request Opportunities](https://github.com/MunGell/awesome-for-beginners/).
 
 ## The projects
+
+These are projects and lists of projects you can contribue to.
 
 - [List of all the awesome lists](https://github.com/szabgab/awesome-lists) - A collection of URLs. Excellent way to send your first pull-request.
 - [List of Open Source projects](https://github.com/OSDC-Code-Maven/open-source-by-organizations/) by corporations, Higher Education Institutions, and governments
@@ -19,30 +21,35 @@ Inspired by [Awesome First Pull Request Opportunities](https://github.com/MunGel
 - [AI Language Partner](https://github.com/duct-tape2/ai-language-partner/blob/main/docs/community/CONTRIBUTOR_LANDING.md): Local-first Japanese speaking practice app for Korean learners. Non-programmers can improve Korean/Japanese docs, review beginner dialogue naturalness, and add learner notes through [first-timers-only issues](https://github.com/duct-tape2/ai-language-partner/labels/first-timers-only).
 - [LanguageTool](https://github.com/languagetool-org/languagetool): [LanguageTool](https://community.languagetool.org/) is an Open Source proofreading tool.
 - [swag-for-dev](https://github.com/swapagarwal/swag-for-dev): 😎👕🧦 A list of swag opportunities for developers.
-- [awesome-eli5](https://github.com/swapagarwal/awesome-eli5): 👶 Tech explained like you're five!
-- [awesome-inspiration](https://github.com/swapagarwal/awesome-inspiration): 🔥 A curated list of content worth sharing to help you get inspired! ⚡️.
 - [Oppia](https://github.com/oppia/oppia/wiki/Teaching-with-Oppia): [Oppia](https://www.oppia.org) is an online learning tool that enables anyone to easily create and share interactive activities.
-- [A-to-Z-Resources-for-Students](https://github.com/dipakkr/A-to-Z-Resources-for-Students): This is a dynamic list for everything you need to know for coders and non-coders. Make yourself comfortable updating the list and using any of the resources listed.
-- [Hello World](https://guides.github.com/activities/hello-world/): A short tutorial on how to start contributing with GitHub.
 - [Awesome Animal Care](https://github.com/omkar-foss/awesome-animal-care): List of curated, practical information resources to care for dogs, cats, fishes, horses, parrots and others.
 - [Awesome App Ideas](https://github.com/tastejs/awesome-app-ideas): A list of app ideas. You can add your own app ideas. Non-Programmers can create app ideas for programmers looking through the list to solve.
 - [Awesome Fantasy](https://github.com/RichardLitt/awesome-fantasy): A list of fantasy books and TV-series that anyone can contribute to.
-- [First Contributions](https://github.com/firstcontributions/first-contributions): Quick guide on forks, pull requests and contributions.
-- [Flexbox Froggy](https://github.com/thomaspark/flexboxfroggy): Learn CSS Flexbox while playing!
-- [Learn Git branching](https://pcottle.github.io/learnGitBranching): Play the game and learn Git branching.
-- [DX Knowledge Base](https://github.com/DXHeroes/knowledge-base-content): Open source Knowledge Base filled with articles about Developer Experience and related topics like software creation process and team management.
 - [DevJoke](https://github.com/shrutikapoor08/devjoke): #DevJoke. Submit a PR if you know a good dev joke.
 - [LaTeX Gboard Dictionary](https://github.com/DenverCoder1/LaTeX-Gboard-Dictionary/issues/5): ⌨ Add shortcuts to a Gboard dictionary to allow Unicode to be typed with simple shortcuts on Android ⚡.
 - [Open Source Practice and Resources](https://github.com/Ashish-khanagwal/Open-source-practice-and-resources): Make your first pull request with beginner friendly project, just add relevant resources which you find beneficial and adding values to your learning journey💪.
 - [Open Drinks](https://github.com/alfg/opendrinks): Submit drink recipes.
 - [The Sourdough Framework](https://github.com/hendricius/the-sourdough-framework): An opportunity to share your bread / sourdough recipes!
-- [GitHub for Non-Programmers](https://github.com/tvanantwerp/github-for-non-programmers): Guide on using GitHub for workflows other than programming.
 - [Data Science Notes](https://github.com/wyattowalsh/data-science-notes): Share notes across topics in data science such as mathematics, visualization, and modeling!
 - [CheatSheets](https://github.com/Jahenr/CheatSheets): Cheat sheet documentation project that allows contributors to add and reference most common commands for systems we know and love in a single place.
 - [Owncast](https://github.com/owncast/owncast): A self-hosted livestreaming video and chat server that allows you to build experiences similar, but not limited to, big tech owned services. A great project for those interested in design, media, documentation, tutorials or community engagement.
-- [Useful repositories](https://github.com/Aatmaj-Zephyr/A-collection-of-useful-repositories): A collection of useful repositories which provide learning resources for developers.
 - [PetMe](https://github.com/akshitagupta15june/PetMe): A platform for finding homes for animals in need, always open to contributions.
 - [The Turing Way](https://github.com/alan-turing-institute/the-turing-way): A series of open source guides about data science and AI. Contributors can add to new and ongoing chapters, work on translation efforts, contribute to infrastructure maintenance work within the project, and more.
+
+## The resources
+
+These are resources that will help you contribute to projects (and can be contributed to themselves!)
+
+- [awesome-eli5](https://github.com/swapagarwal/awesome-eli5): 👶 Tech explained like you're five!
+- [awesome-inspiration](https://github.com/swapagarwal/awesome-inspiration): 🔥 A curated list of content worth sharing to help you get inspired! ⚡️.
+- [A-to-Z-Resources-for-Students](https://github.com/dipakkr/A-to-Z-Resources-for-Students): This is a dynamic list for everything you need to know for coders and non-coders. Make yourself comfortable updating the list and using any of the resources listed.
+- [Hello World](https://guides.github.com/activities/hello-world/): A short tutorial on how to start contributing with GitHub.
+- [First Contributions](https://github.com/firstcontributions/first-contributions): Quick guide on forks, pull requests and contributions.
+- [Flexbox Froggy](https://github.com/thomaspark/flexboxfroggy): Learn CSS Flexbox while playing!
+- [Learn Git branching](https://pcottle.github.io/learnGitBranching): Play the game and learn Git branching.
+- [DX Knowledge Base](https://github.com/DXHeroes/knowledge-base-content): Open source Knowledge Base filled with articles about Developer Experience and related topics like software creation process and team management.
+- [GitHub for Non-Programmers](https://github.com/tvanantwerp/github-for-non-programmers): Guide on using GitHub for workflows other than programming.
+- [Useful repositories](https://github.com/Aatmaj-Zephyr/A-collection-of-useful-repositories): A collection of useful repositories which provide learning resources for developers.
 - [Basic Github commands](https://github.com/LiviaGitHub/basic-github-commands): This repository serves as a comprehensive guide to the fundamental commands of Git. Whether you are a beginner or looking to refresh your knowledge, this repository provides clear explanations and practical examples of essential Git commands. Contributors can enhance this project by adding new chapters or expanding ongoing ones, working on translation efforts to make the content accessible to a broader audience, providing feedback and suggestions for better documentation.
 
 ## Inactive projects


### PR DESCRIPTION
Some items in the projects list were clearly included as guides for non-programmers to follow rather than projects for non-programmers to contribute to. I have split these into two lists and alphabetised them, using my best guess when an item fell into both categories. Also changed the `Inactive Projects` description for consistency, and specified how non-programmers can contribute to this repo under `Contributing to this list`.